### PR TITLE
Adding "display: flex" to parent div

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -3,10 +3,12 @@
     box-sizing: border-box;
 }
 
-
-.card {
+.credit-list {
     display: flex;
     flex-direction: row;
+}
+
+.card {
     /* width:300px; */
     /* height:200px; */
     margin: 0;

--- a/src/App.js
+++ b/src/App.js
@@ -13,12 +13,11 @@ function CreateCredit(info){
 }
 
 function App() {
-  return <div className="credit-list">
-{creditlist.map(CreateCredit)}
-  </div>
-
-
-
+  return (
+    <div className="credit-list">
+      {creditlist.map(CreateCredit)}
+    </div>
+  )
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import creditlist from "./Creditlist";
 
 
 function CreateCredit(info){
-  return <Credit 
+  return <Credit
     key={info.key}
     name={info.name}
     img={info.img}
@@ -13,12 +13,12 @@ function CreateCredit(info){
 }
 
 function App() {
-  return <div>
+  return <div className="credit-list">
 {creditlist.map(CreateCredit)}
   </div>
-  
-   
-  
+
+
+
 }
 
 export default App;

--- a/src/components/Credit.jsx
+++ b/src/components/Credit.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function Credits(props) {
+function Credit(props) {
 
 return (<div className="card darken">
    <img className="credit-img" src={props.img} />
@@ -14,4 +14,4 @@ return (<div className="card darken">
 
 }
 
-export default Credits;
+export default Credit;


### PR DESCRIPTION
Hey @tompovey48
The problem was that `display: flex;` needs to be on the parent element around the children elements that you want to flex. I added a `.credit-list` CSS class that wraps the `.card` children so now they nicely flex in a row.

Something I didn't fix but thought you might want to is to centre the text of the card over the image. I suggest you make the image a CSS background image rather than an HTML img element. Then you should just be able to flexbox the `.card`s 👍 